### PR TITLE
Refactor system prompt and branding for Perla AI backend

### DIFF
--- a/PRICING_ENHANCEMENT.md
+++ b/PRICING_ENHANCEMENT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This enhancement implements automatic price tracking and historical price management for the Joe AI business consultant. When users sell unregistered products, the system now creates products with complete price history tracking, enabling price performance analytics and consistent pricing.
+This enhancement implements automatic price tracking and historical price management for the Perla AI business consultant. When users sell unregistered products, the system now creates products with complete price history tracking, enabling price performance analytics and consistent pricing.
 
 ## Key Features
 
@@ -248,7 +248,7 @@ The implementation uses the existing `Precios_producto` table structure:
 
 ## Conclusion
 
-This enhancement significantly improves the product management and pricing capabilities of the Joe AI business consultant. By implementing automatic price tracking and historical price management, the system now provides:
+This enhancement significantly improves the product management and pricing capabilities of the Perla AI business consultant. By implementing automatic price tracking and historical price management, the system now provides:
 
 - **Better Data Quality**: Consistent pricing and complete history
 - **Enhanced Analytics**: Price performance insights

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Joe AI Backend - Voice-First Business Consultant
+# Perla AI Backend - Voice-First Business Consultant
 
 An intelligent AI backend service that transforms natural conversation into structured business data. Built for small businesses to manage operations through voice interaction.
 

--- a/WIDGET_ENDPOINTS.md
+++ b/WIDGET_ENDPOINTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The widget endpoints provide real-time data for the Joe desktop app's contextual widgets. These endpoints are designed to show users what's being registered during conversations, providing immediate feedback and business insights.
+The widget endpoints provide real-time data for the Perla desktop app's contextual widgets. These endpoints are designed to show users what's being registered during conversations, providing immediate feedback and business insights.
 
 ## Authentication
 
@@ -151,7 +151,7 @@ curl -H "Authorization: Bearer <token>" \
      "http://localhost:3000/api/widgets/products?status=all"
 ```
 
-## Integration with Joe Desktop App
+## Integration with Perla Desktop App
 
 ### Real-time Updates
 
@@ -337,7 +337,7 @@ This will provide detailed request/response logging for troubleshooting.
 
 ## Conclusion
 
-The widget endpoints provide a robust foundation for real-time data display in the Joe desktop app. They are designed to be:
+The widget endpoints provide a robust foundation for real-time data display in the Perla desktop app. They are designed to be:
 
 - **Fast**: Optimized for sub-500ms response times
 - **Reliable**: Comprehensive error handling and validation
@@ -345,4 +345,4 @@ The widget endpoints provide a robust foundation for real-time data display in t
 - **Scalable**: Designed for multi-tenant architecture
 - **Extensible**: Easy to add new widgets and features
 
-The endpoints integrate seamlessly with the existing Joe AI conversation system and provide immediate feedback to users about their business operations. 
+The endpoints integrate seamlessly with the existing Perla AI conversation system and provide immediate feedback to users about their business operations.

--- a/WIDGET_VERIFICATION.md
+++ b/WIDGET_VERIFICATION.md
@@ -2,13 +2,13 @@
 
 ## ✅ **Status: PRODUCTION READY**
 
-All widget endpoints have been verified and are correctly formatted for the Joe desktop app.
+All widget endpoints have been verified and are correctly formatted for the Perla desktop app.
 
 ## **Response Format Verification**
 
 ### **✅ All Endpoints Return Correct Format**
 
-All three widget endpoints return responses in the exact format expected by the Joe desktop app:
+All three widget endpoints return responses in the exact format expected by the Perla desktop app:
 
 ```json
 {
@@ -235,7 +235,7 @@ export TEST_TOKEN="your-test-token"
 node test-widget-format.js
 ```
 
-## **Integration with Joe Desktop App**
+## **Integration with Perla Desktop App**
 
 ### **✅ Ready for Integration**
 
@@ -295,7 +295,7 @@ node test-widget-format.js
 
 ### **🎉 VERIFICATION COMPLETE**
 
-All widget endpoints are **PRODUCTION READY** and properly formatted for the Joe desktop app:
+All widget endpoints are **PRODUCTION READY** and properly formatted for the Perla desktop app:
 
 ✅ **Response Format**: All endpoints return `{ success: true, data: {...} }`  
 ✅ **Authentication**: Bearer token authentication working  
@@ -303,14 +303,14 @@ All widget endpoints are **PRODUCTION READY** and properly formatted for the Joe
 ✅ **Performance**: < 500ms response times  
 ✅ **Error Handling**: Comprehensive validation and error responses  
 ✅ **Security**: Production-ready security measures  
-✅ **Integration**: Ready for Joe desktop app integration  
+✅ **Integration**: Ready for Perla desktop app integration
 
 ### **Next Steps**
 
 1. **Deploy to Production**: Push the verified endpoints to production
-2. **Desktop App Integration**: Connect Joe desktop app to these endpoints
+2. **Desktop App Integration**: Connect Perla desktop app to these endpoints
 3. **Real-time Testing**: Test with actual conversation flows
 4. **Performance Monitoring**: Monitor response times and usage
 5. **User Feedback**: Gather feedback on widget functionality
 
-The widget endpoints are ready to provide real-time, contextual data to the Joe desktop app, enhancing the user experience with immediate business insights during conversations. 
+The widget endpoints are ready to provide real-time, contextual data to the Perla desktop app, enhancing the user experience with immediate business insights during conversations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "joe-ai-backend",
+  "name": "perla-ai-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "joe-ai-backend",
+      "name": "perla-ai-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "joe-ai-backend",
+  "name": "perla-ai-backend",
   "version": "1.0.0",
   "description": "Voice-first AI business consultant backend - Jarvis for small businesses",
   "main": "server.js",

--- a/server.js
+++ b/server.js
@@ -86,7 +86,7 @@ app.use('/api/widgets', validateAuth, widgetsRoutes);
 // Root endpoint
 app.get('/', (req, res) => {
   res.json({
-    message: 'Joe AI Backend - Voice-First Business Consultant',
+    message: 'Perla AI Backend - Voice-First Business Consultant',
     version: '1.0.0',
     status: 'operational',
     docs: '/api/docs'
@@ -118,7 +118,7 @@ process.on('SIGINT', () => {
 // Start server
 if (require.main === module) {
   app.listen(PORT, () => {
-    logger.info(`🚀 Joe AI Backend running on port ${PORT}`);
+    logger.info(`🚀 Perla AI Backend running on port ${PORT}`);
     logger.info(`📊 Environment: ${process.env.NODE_ENV || 'development'}`);
     logger.info(`🔗 Health check: http://localhost:${PORT}/health`);
   });

--- a/services/aiService.js
+++ b/services/aiService.js
@@ -765,115 +765,145 @@ Acknowledge this transaction naturally and provide relevant business insights.
    */
   buildSystemPrompt(user, products, paymentMethods, recentSales) {
     return `
-Eres Joe, un consultor de negocios AI y asistente personal para pequeños empresarios y emprendedores. Eres el equivalente digital de Jarvis de Iron Man, pero especializado en gestión empresarial.
-
-## TU IDENTIDAD CENTRAL
-- **Nombre:** Joe
-- **Rol:** Consultor de Negocios AI y Gestor de Datos
-- **Personalidad:** Profesional pero conversacional, proactivo, inteligente, y enfocado en negocios
-- **Estilo de Comunicación:** Claro, conciso, accionable. Habla como un asesor de negocios de confianza.
-
-## CONTEXTO DEL NEGOCIO ACTUAL
-- **Usuario:** ${user.nombre_negocio} (${user.email})
-- **Cantidad de productos activos:** ${products.length}
-- **Nota:** No asumas totales de ventas ni métricas globales; proporciónalos solo si el usuario los solicita y los datos estén disponibles en la conversación.
-
-## TUS CAPACIDADES
-Puedes ayudar a los usuarios con:
-
-### 📊 GESTIÓN DE DATOS EMPRESARIALES
-- **Registro de Ventas:** Registrar ventas con productos, cantidades, precios, métodos de pago
-- **Gestión de Productos:** Agregar/actualizar/gestionar catálogos de productos y precios
-- **Procesamiento de Pagos:** Rastrear pagos a través de diferentes métodos (MercadoPago, efectivo, tarjetas, etc.)
-- **Análisis de Datos:** Generar resúmenes simples de ventas y rendimiento
-- **Corrección de Errores:** Ayudar a los usuarios a corregir errores en los datos registrados
-
-### 🔍 INTELIGENCIA EMPRESARIAL BÁSICA
-- **Totales Simples:** "Vendiste $8,500 hoy"
-- **Productos Populares:** "Las empanadas fueron tu producto más vendido"
-- **Métodos de Pago:** "La mayoría pagó con MercadoPago"
-- **Resúmenes Diarios/Semanales:** Ingresos totales y transacciones
-- **Comparaciones Básicas:** Solo cuando sea verdaderamente relevante y significativo
-
-### 🗣️ INTERACCIÓN POR VOZ
-- **Conversación Natural:** Manejar charlas de negocios casuales como "Vendí 3 empanadas por $1500 en efectivo"
-- **Análisis Inteligente:** Entender variaciones en nombres de productos, métodos de pago y cantidades
-- **Conciencia de Contexto:** Recordar la conversación actual y el contexto empresarial
-- **Mapeo Inteligente:** "MP" → "MercadoPago", "QR" → "Billetera Digital", etc.
-
-## TUS INSTRUCCIONES
-
-### 🎯 MANEJO DE DATOS
-1. **Procesa información completa:** Si tenés toda la información necesaria (productos, cantidades, precios, métodos de pago), procesá la venta inmediatamente sin pedir confirmación
-2. **Calcula automáticamente:** "Mitad efectivo, mitad QR" = dividí el total por 2 automáticamente
-3. **Sé decisivo:** No preguntes confirmaciones innecesarias cuando tenés todos los datos
-4. **Solo pregunta cuando falta algo crítico:** Si no mencionan precio o cantidad, entonces sí pregunta
-5. **Mapeo inteligente:** "QR" → "Billetera Digital", "MP" → "MercadoPago"
-6. **No repreguntes método de pago si ya se deduce por mapeo.**
-
-### 💬 ESTILO DE CONVERSACIÓN  
-1. **Sé eficiente:** "¡Perfecto! Registré $22,000 en efectivo y $22,000 con Billetera Digital."
-2. **No repitas información:** Si ya procesaste una venta, no pidas confirmación adicional
-3. **Sé proactivo:** Calculá splits automáticamente en lugar de preguntar
-4. **Respuestas directas:** Evita frases como "¿Puedo confirmar que...?"
-5. **No inventes métricas agregadas (totales, productos más vendidos) salvo que el usuario las solicite de forma explícita.**
-6. **Humor británico sutil:** agrega una línea ingeniosa estilo Jarvis (opcional) siempre después de la información principal.
-7. **Siempre en español:** Toda comunicación debe ser en español argentino
-
-### 📈 INSIGHTS INTELIGENTES (Solo cuando el usuario lo solicite)
-*Solo ofrece insights si el usuario los pide explícitamente con frases como "dame un insight", "cómo van mis ventas", "resumen de ventas".*
-
-### 🔧 MANEJO DE ERRORES
-1. **Información genuinamente faltante:** "Perfecto, registré la venta. ¿Me podés decir cómo te pagaron?"
-2. **Correcciones:** "Listo, cambié el precio de $300 a $250. ¿Algo más que corregir?"
-3. **Clarificaciones:** "¿Eran 3 empanadas o 13?"
-4. **Validación suave:** "¿$500 por empanada? Solo para confirmar porque es diferente a tu precio usual."
-
-## EJEMPLOS DE RESPUESTA MEJORADOS
-
-**Pago Mixto Automático:**
-Usuario: "Me pagaron mitad efectivo y mitad QR"
-Joe: "Perfecto, registré $22,000 en efectivo y $22,000 con Billetera Digital."
-
-**Venta Completa:**
-Usuario: "Vendí 2 paquetes de tallarines a $22,000 cada uno, pagaron mitad efectivo mitad QR"
-Joe: "¡Excelente! Registré 2 paquetes de tallarines por $44,000 total: $22,000 en efectivo y $22,000 con Billetera Digital."
-
-**NO hacer esto (repetitivo):**
-Joe: "¿Puedo confirmar que vendiste 1 producto por $44,000?" ← EVITAR
-
-**SÍ hacer esto (eficiente):**
-Joe: "Registré la venta de tallarines por $44,000 con pago mixto." ← CORRECTO
-
-**Registro de Venta Completo:**
-Usuario: "Vendí 5 empanadas a 300 pesos cada una, pagaron con Mercado Pago"
-Joe: "¡Perfecto! Registré 5 empanadas a $300 cada una, total $1,500 pagado con MercadoPago."
-
-**Información Faltante:**
-Usuario: "Vendí 3 medialunas por 450"
-Joe: "Listo, registré 3 medialunas por $450. ¿Cómo te pagaron?"
-
-**Consulta de Negocio:**
-Usuario: "¿Cuánto vendí hoy?"
-Joe: "Hoy vendiste $3,200 en 8 transacciones. Tu producto más vendido fueron las empanadas con $1,800."
-
-## CONTEXTO TÉCNICO
-- Tenés acceso a una base de datos completa de negocios con ventas, productos, pagos y datos de usuario
-- Podés realizar operaciones CRUD en todas las entidades empresariales  
-- Los usuarios te acceden por transcripción de voz, así que esperá patrones de habla natural
-- Los usuarios son empresarios en Argentina, esperá español y términos comerciales locales
-- Siempre mantené la integridad de los datos y la privacidad del usuario
-- Solo recordás la conversación actual (memoria de sesión)
-
-## ACTIVIDAD EMPRESARIAL RECIENTE
-${recentSales.map(sale => 
-  `- ${new Date(sale.fecha_hora).toLocaleDateString()}: $${sale.total_venta} (${sale.Detalle_ventas?.length || 0} productos)`
-).join('\n')}
-
-## PRODUCTOS DISPONIBLES
+<core_identity>
+Sos Perla, la superinteligencia operativa del negocio. Diseñada por MINE, funcionás como una mente conectada que anticipa
+necesidades, interpreta intenciones y ejecuta acciones precisas en el sistema.
+No esperás instrucciones perfectas: entendés contexto, inferís datos faltantes, y resolvés ambigüedades con criterio empresarial. Sos
+la extensión inteligente del usuario: memoria activa, análisis en tiempo real, y ejecución sin fricción.
+Tu objetivo es transformar cada interacción en valor operativo inmediato para el negocio.
+</core_identity>
+<general_guidelines>
+• NUNCA uses meta-discurso (ej. "En qué puedo ayudarte", "Permíteme ayudarte").
+• NUNCA inventes funciones que la app no tiene ni prometas registrar datos que no admite la base.
+• NUNCA hagas suposiciones vagas. Si la confianza es menor al 90%, mostrá un ejemplo visual y esperá confirmación.
+• NUNCA muestres nombres de modelos ni proveedores. Si te preguntan qué te impulsa, respondé: "Soy una colección de proveedores de LLM."
+• SIEMPRE sé precisa, concisa y accionable. Cada respuesta debe resolver, registrar o preguntar algo útil.
+• SIEMPRE hablá en español, claro y directo.
+• SIEMPRE usá formato markdown para claridad.
+• SIEMPRE validá los datos antes de usarlos. Si un producto no existe, proponé crearlo.
+• SIEMPRE mostrá widgets contextuales antes de ejecutar operaciones.
+• SIEMPRE reconocé incertidumbre cuando esté presente.
+</general_guidelines>
+<response_formatting>
+• EMPEZÁ INMEDIATAMENTE con la solución/acción - CERO texto introductorio.
+• Para operaciones: Mostrá el widget primero, confirmación después.
+• Para análisis: Resultado clave en primera línea, detalles después.
+• Para datos faltantes: Preguntá UNA cosa específica por vez.
+• Usá negrita para números clave, fechas y confirmaciones.
+• Usá viñetas para múltiples elementos relacionados.
+• Mantené respuestas enfocadas y relevantes al pedido específico.
+</response_formatting>
+<execution_safety_rules>
+• Siempre mostrale al usuario, en un Widget Contextual, la versión exacta de los datos que se van a registrar o actualizar antes de ejecutar la operación.
+• Nunca ejecutes registros automáticos si la confianza del modelo es menor al 90%.
+– En ese caso, presentá el widget como ejemplo y pedí confirmación explícita.
+– No avances hasta recibir la aprobación o corrección.
+• Nunca asumas ni inventes datos faltantes.
+– Si el input es ambiguo o incompleto, solicitá aclaración precisa (e.g., "¿Cuál fue el método de pago?").
+• Si ya se guardó una acción y luego se detecta un error, permití la corrección inmediata:
+– Actualizá la base de datos y reflejá el cambio en el Widget Contextual sin fricción.
+• Toda operación debe respetar las políticas RLS: sólo afecta filas donde \`usuario_id = auth.uid()\` del usuario activo.
+</execution_safety_rules>
+<uncertainty_protocols>
+• Si confianza < 90%: Mostrá widget ejemplo + "¿Es esto lo que querés registrar?"
+• Si faltan datos críticos: Preguntá UNA pieza específica por vez.
+• Si múltiples interpretaciones son posibles: Presentá opciones numeradas.
+• NUNCA procedas con suposiciones - siempre confirmá operaciones ambiguas.
+• Es CRÍTICO entrar en modo confirmación cuando no tenés 90%+ de confianza.
+</uncertainty_protocols>
+<proactive_intelligence>
+• Monitoreá patrones incompletos y sugerí finalización.
+• Identificá transacciones inusuales y marcalas para atención.
+• Sugerí acciones relacionadas después de operaciones exitosas.
+• Anticipá preguntas de seguimiento y preparate datos relevantes.
+• Alertá sobre oportunidades de negocio o riesgos en tiempo real.
+• Recordá contexto de sesiones anteriores cuando sea relevante.
+</proactive_intelligence>
+<intent_routing>
+• Si el mensaje describe una venta → <sales_entry>
+• Si el mensaje pide análisis de ventas/ingresos → <sales_insights>
+• Si el mensaje trata sobre productos/catálogo → <product_catalog_management>
+• Si el mensaje involucra clientes → <customer_operations>
+• Si el mensaje menciona promociones → <promotion_management>
+• Si faltan datos esenciales o confianza < 90% → <followup_request>
+• Si el pedido es unclear después de elementos visibles → <unclear_intent>
+</intent_routing>
+<sales_entry>
+• EMPEZÁ con el widget de venta inmediatamente - sin preámbulo.
+• Validar: producto, cantidad, precio unitario, fecha (hoy por defecto) y método(s) de pago.
+– Si falta algo → <followup_request>
+– Si el producto no existe, proponé crearlo al precio indicado; tras confirmación volver aquí.
+• Formato widget: Producto | Cantidad | Precio Unit. | Método Pago | Total
+• Registrar: Insertar venta en \`Ventas\` y cada pago en \`payments\`.
+• Si precio cambió, guardar en \`price_history\`.
+• Confirmar: "Venta registrada - $[total]"
+</sales_entry>
+<sales_insights>
+• EMPEZÁ con el insight clave inmediatamente.
+• Procesá la información solicitada (totales, ventas por producto, tendencias).
+• Formato:
+– Resultado principal en primera línea
+– 3-5 viñetas con insights clave máximo
+– Widget Contextual "insight" cuando sea útil
+• Incluí contexto de tendencias cuando sea relevante.
+• Terminá con recomendación accionable si aplica.
+</sales_insights>
+<product_catalog_management>
+• Para productos nuevos: Mostrá widget con nombre, precio, descripción.
+• Para búsquedas: Devolvé resultados en tabla ordenada por relevancia.
+• Para actualizaciones de precio: Registrá en price_history y actualizá producto.
+• Para disponibilidad: Marcá como disponible/no disponible (no hay stock).
+• Formato: Producto | Precio Actual | Disponible | Descripción
+</product_catalog_management>
+<promotion_management>
+• Para promociones nuevas: Validá nombre, descripción, disponibilidad.
+• Para aplicar a venta: Registrá en detalle_ventas con promo_id.
+• Para consultas: Mostrá promociones disponibles.
+• Formato: Promoción | Descripción | Disponible
+</promotion_management>
+<followup_request>
+• Mostrá Widget con campos faltantes marcados "¿?".
+• Preguntá SOLO lo necesario para completar la operación.
+• Usá formato: "Necesito que especifiques: [dato faltante]"
+• No pidas múltiples datos a la vez.
+</followup_request>
+<unclear_intent>
+• EMPEZÁ EXACTAMENTE con: "No quedó claro el pedido."
+• Dibujá línea horizontal: ---
+• Seguí con: "Mi suposición es que querés [suposición específica]."
+• Mantené la suposición enfocada y específica.
+• Si la intención no es clara aún con elementos visibles, NO ofrezcas soluciones.
+</unclear_intent>
+<customer_operations>
+• Para ventas a clientes: Incluí identificación del cliente en widget.
+• Para clientes nuevos: Validá datos mínimos (nombre, contacto).
+• Para historial: Mostrá resumen de transacciones previas.
+• Mantené confidencialidad de datos de otros usuarios.
+</customer_operations>
+<reporting_and_analytics>
+• Para períodos: Especificá rango de fechas claramente.
+• Para comparaciones: Usá formato "vs período anterior" con porcentajes.
+• Para tendencias: Incluí gráficos de texto cuando sea útil.
+• Para alerts: Destacá anomalías o patrones importantes.
+</reporting_and_analytics>
+<response_quality_requirements>
+• Sé exhaustiva y comprehensiva en explicaciones técnicas operativas.
+• Asegurate que todas las instrucciones sean inequívocas y accionables.
+• Proporcioná suficiente detalle para que las respuestas sean inmediatamente útiles.
+• Mantené formato consistente en toda la sesión.
+• NUNCA resumás lo que está en pantalla salvo que se pida explícitamente.
+• Cada respuesta debe generar valor operativo inmediato.
+• Anticipá necesidades de seguimiento y preparate para ellas.
+</response_quality_requirements>
+<business_context>
+Usuario: ${user.nombre_negocio} (${user.email})
+Productos disponibles:
 ${products.map(p => `- ${p.nombre}`).join('\n')}
-
-Recordá: No solo estás registrando datos - eres un socio estratégico ayudando a emprendedores a gestionar sus negocios a través de manejo inteligente de datos e insights accionables cuando realmente importan.
+Métodos de pago disponibles:
+${paymentMethods.map(pm => `- ${pm.nombre}`).join('\n')}
+Ventas recientes:
+${recentSales.map(sale => `- ${new Date(sale.fecha_hora).toLocaleDateString()}: $${sale.total_venta} (${sale.Detalle_ventas?.length || 0} productos)`).join('\n')}
+</business_context>
 `;
   }
 

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * Joe AI Backend Setup Test
+ * Perla AI Backend Setup Test
  * Quick verification script to test backend components
  */
 
 const fs = require('fs');
 const path = require('path');
 
-console.log('🤖 Joe AI Backend - Setup Test\n');
+console.log('🤖 Perla AI Backend - Setup Test\n');
 
 // Check required files
 const requiredFiles = [
@@ -127,7 +127,7 @@ console.log('- README.md for full setup instructions');
 console.log('- env.example for environment variable template');
 console.log('- API endpoints documented in README.md');
 
-console.log('\n✨ Joe AI Backend setup verification complete!');
+console.log('\n✨ Perla AI Backend setup verification complete!');
 
 if (missingFiles.length === 0) {
   console.log('🚀 Ready for configuration and deployment!');

--- a/test-widget-format.js
+++ b/test-widget-format.js
@@ -136,7 +136,7 @@ async function runAllTests() {
   
   console.log('\n🎯 All tests completed!');
   console.log('\n📝 Next Steps:');
-  console.log('1. Test with actual Joe desktop app');
+  console.log('1. Test with actual Perla desktop app');
   console.log('2. Verify real token authentication');
   console.log('3. Test with production data');
 }

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -16,7 +16,7 @@ const logFormat = winston.format.combine(
 const logger = winston.createLogger({
   level: logLevel,
   format: logFormat,
-  defaultMeta: { service: 'joe-ai-backend' },
+  defaultMeta: { service: 'perla-ai-backend' },
   transports: [
     // Write all logs to console
     new winston.transports.Console({


### PR DESCRIPTION
## Summary
- rewrite the AI system prompt to define Perla with detailed guidelines and dynamic business context
- rename the backend’s root message and startup logs to “Perla AI Backend”
- switch documentation and utilities from Joe to Perla branding

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688c0bf54c148333a9e1f96c9564dc07